### PR TITLE
53 add graph loader

### DIFF
--- a/base/src/CMakeLists.txt
+++ b/base/src/CMakeLists.txt
@@ -11,6 +11,8 @@ FILE(GLOB_RECURSE TinyUSBCSources ${TINYUSB_PATH}/src/*.c)
 # c and c++ files for both host and ARM build
 set(CROSS_PLATFORM_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/modules/graph_runner.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/modules/graph_loader.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/modules/module_loader.cpp
 )
 
 # SOURCES for ARM build only
@@ -76,7 +78,7 @@ if (BUILD_ARM)
 	# Create binary file
 	add_custom_target(${PROJECT_NAME}.bin ALL DEPENDS ${PROJECT_NAME}.elf)
 	add_custom_command(TARGET ${PROJECT_NAME}.bin COMMAND ${CMAKE_OBJCOPY} ARGS -O binary ${PROJECT_NAME}.elf ${PROJECT_NAME}.bin)
-    
+
 else()
 	add_subdirectory(third_party/googletest)
 

--- a/base/src/modules/graph.hpp
+++ b/base/src/modules/graph.hpp
@@ -8,12 +8,13 @@ namespace graph_infrastructure {
 
 ///
 /// Structure for defining a connection between modules.
+/// Data flows from module output -> module input.
 ///
 struct Connection {
-    size_t inModIdx;   ///< Module index of connection input
-    size_t inPortIdx;  ///< Port index of connection input
-    size_t outModIdx;  ///< Module index of connection output
-    size_t outPortIdx; ///< Port index of connection ouptut
+    size_t inModIdx;   ///< Module to input into
+    size_t inPortIdx;  ///< Port to to input into
+    size_t outModIdx;  ///< Module to get the output from
+    size_t outPortIdx; ///< Port to get the output from
 };
 
 ///

--- a/base/src/modules/graph_loader.cpp
+++ b/base/src/modules/graph_loader.cpp
@@ -1,9 +1,8 @@
 #include "graph_loader.hpp"
-#define ARDUINOJSON_ENABLE_STD_STRING 1
-#include <ArduinoJson.hpp>
 
 namespace graph_infrastructure {
 
+// JSON keys for graph parsing.
 static const char* scModulesJsonKey = "modules";
 static const char* scModuleIdJsonKey = "id";
 static const char* scModuleArgsJsonKey = "args";
@@ -13,6 +12,7 @@ static const char* scConnectionsOutputModJsonKey = "output_mod";
 static const char* scConnectionsInputPortNameJsonKey = "input_port_name";
 static const char* scConnectionsOutputPortNameJsonKey = "output_port_name";
 
+// Shared loading failure messages.
 static const char* scInvalidConnectionInputMod = "Invalid connection input module";
 static const char* scInvalidConnectionOutputMod = "Invalid connection output module";
 
@@ -84,16 +84,15 @@ void GraphLoader::validateGraph(Graph* graph) {
             throw "Invalid connection output port";
         }
     }
-
-    // TODO: Check The inputs of every module is pointed to by 0 or 1 connection.
 }
+
 ///
-/// Load a new graph from input
-/// @param buf
-/// @param len
-/// @return 
+/// Load a new graph from input.
+/// @param buf Buffer to parse for graph description.
+/// @param len Length of buffer.
+/// @return New graph ready to be run.
+/// @note The GraphLoader is responsible for the memory management of this graph.
 ///
-// TODO: Split this up
 Graph* GraphLoader::load(char* buf, size_t len) {
     ArduinoJson::JsonDocument doc;
     ArduinoJson::DeserializationError err = deserializeJson(doc, buf, len);
@@ -104,19 +103,29 @@ Graph* GraphLoader::load(char* buf, size_t len) {
         throw "JSON parsing error";
     }
 
-    // Check for high level keys
+    // Prepare graph for loading.
+    clearGraph(mLoadingGraph);
+
+    parseModules(obj);
+    parseConnections(obj);
+
+    // No errors occured during loading, swap loading and runnable graph and return.
+    Graph* temp = mRunnableGraph;
+    mRunnableGraph = mLoadingGraph;
+    mLoadingGraph = temp;
+
+    return mRunnableGraph;
+}
+
+///
+/// Parse modules and load into graph.
+/// @param obj JSON object to parse modules from.
+///
+void GraphLoader::parseModules(ArduinoJson::JsonObject& obj) {
     ArduinoJson::JsonArray modules = obj[scModulesJsonKey];
     if(modules.isNull()) {
         throw "Invalid modules key";
     }
-
-    ArduinoJson::JsonArray connections = obj[scModulesJsonKey];
-    if(connections.isNull()) {
-        throw "Invalid connections key";
-    }
-
-    // Prepare graph for loading.
-    clearGraph(mLoadingGraph);
 
     // Parse Modules
     for(ArduinoJson::JsonObject mod : modules) {
@@ -125,10 +134,10 @@ Graph* GraphLoader::load(char* buf, size_t len) {
         }
 
         // Parse module id.
-        if(!mod[scModuleIdJsonKey].is<uint64_t>()) {
+        if(!mod[scModuleIdJsonKey].is<module_basics::ModuleIdType>()) {
             throw "Invalid module ID type";
         }
-        uint64_t moduleId = mod[scModuleIdJsonKey];
+        module_basics::ModuleIdType moduleId = mod[scModuleIdJsonKey];
 
         // Parse module arguments
         ArduinoJson::JsonObject args = mod[scModuleArgsJsonKey];
@@ -156,6 +165,18 @@ Graph* GraphLoader::load(char* buf, size_t len) {
         }
         mLoadingGraph->mods.push_back(newModule);
         newModule->configure(moduleArgs);
+    }
+}
+
+///
+/// Parse connections and load into graph.
+/// @param obj JSON object to parse connections from.
+/// @note @ref All modules should be loaded into the graph before calling this.
+///
+void GraphLoader::parseConnections(ArduinoJson::JsonObject& obj) {
+    ArduinoJson::JsonArray connections = obj[scModulesJsonKey];
+    if(connections.isNull()) {
+        throw "Invalid connections key";
     }
 
     // Parse Connections
@@ -210,13 +231,6 @@ Graph* GraphLoader::load(char* buf, size_t len) {
 
         mLoadingGraph->cons.push_back(newConnection);
     }
-
-    // No errors occured during loading, swap loading and runnable graph and return.
-    Graph* temp = mRunnableGraph;
-    mRunnableGraph = mLoadingGraph;
-    mLoadingGraph = temp;
-
-    return mRunnableGraph;
 }
 
 } // namespace graph_infrastructure

--- a/base/src/modules/graph_loader.cpp
+++ b/base/src/modules/graph_loader.cpp
@@ -43,6 +43,7 @@ GraphLoader::~GraphLoader() {
 ///
 /// Clear a graph.
 /// @param graph The graph to clear.
+/// @note After clear pointer will still point to an empty graph.
 ///
 void GraphLoader::clearGraph(Graph* graph) {
     for(module_basics::ModuleInterface* mod : graph->mods) {
@@ -98,6 +99,8 @@ void GraphLoader::validateGraph(Graph* graph) {
 /// @param len Length of buffer.
 /// @return New graph ready to be run.
 /// @note The GraphLoader is responsible for the memory management of this graph.
+/// @note Every successful load will invalidate the previous pointer returned by load.
+/// @note In the event of a failed load, the previous graph will still be available and it's pointer still valid.
 ///
 Graph* GraphLoader::load(char* buf, size_t len) {
     ArduinoJson::JsonDocument doc;

--- a/base/src/modules/graph_loader.cpp
+++ b/base/src/modules/graph_loader.cpp
@@ -1,3 +1,8 @@
+///
+/// Implements graph JSON schema defined here:
+/// https://github.com/gooey-synths/gooey_specs/blob/0d1f2efd83380fb636a8aa1bcca25e371a73405f/Firmware-Interface.md
+///
+
 #include "graph_loader.hpp"
 
 namespace graph_infrastructure {

--- a/base/src/modules/graph_loader.cpp
+++ b/base/src/modules/graph_loader.cpp
@@ -96,12 +96,12 @@ void GraphLoader::validateGraph(Graph* graph) {
 ///
 Graph* GraphLoader::load(char* buf, size_t len) {
     ArduinoJson::JsonDocument doc;
-    ArduinoJson::DeserializationError err = deserializeJson(doc, buf, len);
+    ArduinoJson::DeserializationError err = deserializeJson(doc, buf);
 
     ArduinoJson::JsonObject obj = doc.as<ArduinoJson::JsonObject>();
 
     if(err) {
-        throw "JSON parsing error";
+        throw err.c_str();
     }
 
     // Prepare graph for loading.
@@ -175,7 +175,7 @@ void GraphLoader::parseModules(ArduinoJson::JsonObject& obj) {
 /// @note All modules should be loaded into the graph before calling this.
 ///
 void GraphLoader::parseConnections(ArduinoJson::JsonObject& obj) {
-    ArduinoJson::JsonArray connections = obj[scModulesJsonKey];
+    ArduinoJson::JsonArray connections = obj[scConnectionsJsonKey];
     if(connections.isNull()) {
         throw "Invalid connections key";
     }

--- a/base/src/modules/graph_loader.cpp
+++ b/base/src/modules/graph_loader.cpp
@@ -1,0 +1,214 @@
+#include "graph_loader.hpp"
+#define ARDUINOJSON_ENABLE_STD_STRING 1
+#include <ArduinoJson.hpp>
+
+namespace graph_infrastructure {
+
+static const char* scModulesJsonKey = "modules";
+static const char* scModuleIdJsonKey = "id";
+static const char* scModuleArgsJsonKey = "args";
+static const char* scConnectionsJsonKey = "connections";
+static const char* scConnectionsInputModJsonKey = "input_mod";
+static const char* scConnectionsOutputModJsonKey = "output_mod";
+static const char* scConnectionsInputPortNameJsonKey = "input_port_name";
+static const char* scConnectionsOutputPortNameJsonKey = "output_port_name";
+
+static const char* scInvalidConnectionInputMod = "Invalid connection input module";
+static const char* scInvalidConnectionOutputMod = "Invalid connection output module";
+
+///
+/// Constructor.
+/// @param moduleLoader Module loader to use for loading modules
+///
+GraphLoader::GraphLoader(ModuleLoaderInterface& moduleLoader): mModuleLoader(moduleLoader) {
+    ; // Do nothing.
+}
+
+///
+/// Destructor.
+///
+GraphLoader::~GraphLoader() {
+    clearGraph(&mGraphA);
+    clearGraph(&mGraphB);
+
+    mLoadingGraph = NULL;
+    mRunnableGraph = NULL;
+}
+
+///
+/// Clear a graph.
+/// @param graph The graph to clear.
+///
+void GraphLoader::clearGraph(Graph* graph) {
+    for(module_basics::ModuleInterface* mod : graph->mods) {
+        delete mod;
+    }
+
+    graph->mods.clear();
+    graph->cons.clear();
+}
+
+///
+/// Validate the graph that has been loaded.
+///
+void GraphLoader::validateGraph(Graph* graph) {
+
+    // Check that all module pointers are not NULL
+     for(module_basics::ModuleInterface* mod : graph->mods) {
+        if(mod == NULL) {
+            throw "Invalid module pointer";
+        }
+    }
+
+    // Check that all connections have valid module indices.
+    for(Connection& con : graph->cons) {
+        if(con.inModIdx >= graph->mods.size()) {
+            throw scInvalidConnectionInputMod;
+        }
+
+        if(con.outModIdx >= graph->mods.size()) {
+            throw scInvalidConnectionOutputMod;
+        }
+    }
+
+    // Check that alll connections have a valid module port indices.
+    for(Connection& con : graph->cons) {
+        module_basics::ModuleInterface* inMod = graph->mods[con.inModIdx];
+        module_basics::ModuleInterface* outMod = graph->mods[con.outModIdx];
+
+        if(!inMod->outputExists(con.inPortIdx)) {
+            throw "Invalid connection input port";
+        }
+
+        if(!outMod->inputExists(con.outPortIdx)) {
+            throw "Invalid connection output port";
+        }
+    }
+
+    // TODO: Check The inputs of every module is pointed to by 0 or 1 connection.
+}
+
+Graph* GraphLoader::load(char* buf, size_t len) {
+    ArduinoJson::JsonDocument doc;
+    ArduinoJson::DeserializationError err = deserializeJson(doc, buf, len);
+
+    ArduinoJson::JsonObject obj = doc.as<ArduinoJson::JsonObject>();
+
+    if(err) {
+        throw "JSON parsing error";
+    }
+
+    // Check for high level keys
+    ArduinoJson::JsonArray modules = obj[scModulesJsonKey];
+    if(modules.isNull()) {
+        throw "Invalid modules key";
+    }
+
+    ArduinoJson::JsonArray connections = obj[scModulesJsonKey];
+    if(connections.isNull()) {
+        throw "Invalid connections key";
+    }
+
+    // prepare graph for loading.
+    clearGraph(mLoadingGraph);
+
+    // Parse Modules
+    for(ArduinoJson::JsonObject mod : modules) {
+        if(mod.isNull()) {
+            throw "Invalid module structure";
+        }
+
+        // Parse module id.
+        if(!mod[scModuleIdJsonKey].is<uint64_t>()) {
+            throw "Invalid module ID type";
+        }
+        uint64_t moduleId = mod[scModuleIdJsonKey];
+
+        // Parse module arguments
+        ArduinoJson::JsonObject args = mod[scModuleArgsJsonKey];
+        if(args.isNull()) {
+            throw "Invalid args type";
+        }
+
+        std::unordered_map<std::string, std::string> moduleArgs;
+
+        for (ArduinoJson::JsonPair kv : args) {
+            // JSON keys are always strings
+            std::string key = kv.key().c_str();
+
+            if(!kv.value().is<ArduinoJson::JsonString>()) {
+                throw "Module arguments must be strings";
+            }
+            std::string value = kv.value();
+
+            moduleArgs[key] = value;
+        }
+
+        module_basics::ModuleInterface* newModule = mModuleLoader.loadModule(moduleId);
+        mLoadingGraph->mods.push_back(newModule);
+        newModule->configure(moduleArgs);
+    }
+
+    // Parse Connections
+    for(ArduinoJson::JsonObject connection : connections) {
+        if(connection.isNull()) {
+            throw "Invalid connection structure";
+        }
+
+        // Check that all of the types are expected
+        if(!connection[scConnectionsInputModJsonKey].is<ArduinoJson::JsonInteger>()) {
+            throw "Invalid connection input module type";
+        }
+
+        if(!connection[scConnectionsOutputModJsonKey].is<ArduinoJson::JsonInteger>()) {
+            throw "Invalid connection output module type";
+        }
+
+        if(!connection[scConnectionsInputPortNameJsonKey].is<ArduinoJson::JsonString>()) {
+            throw "Invalid connection input port type";
+        }
+
+        if(!connection[scConnectionsOutputPortNameJsonKey].is<ArduinoJson::JsonString>()) {
+            throw "Invalid connection output port type";
+        }
+
+        // Read and check module indices
+        size_t inputModIdx = connection[scConnectionsInputModJsonKey];
+        size_t outputModIdx = connection[scConnectionsOutputModJsonKey];
+
+        if(inputModIdx >= mLoadingGraph->mods.size()) {
+        throw scInvalidConnectionInputMod;
+        }
+
+        if(outputModIdx >= mLoadingGraph->mods.size()) {
+            throw scInvalidConnectionOutputMod;
+        }
+
+        // Lookup port indices
+        std::string inputPortName = connection[scConnectionsInputPortNameJsonKey];
+        std::string outputPortName = connection[scConnectionsOutputPortNameJsonKey];
+
+        size_t inputPortIdx = mLoadingGraph->mods[inputModIdx]->getInputIdx(inputPortName);
+        size_t outputPortIdx = mLoadingGraph->mods[outputModIdx]->getOutputIdx(outputPortName);
+
+        // Create new connection
+        Connection newConnection = {
+            .inModIdx = inputModIdx,
+            .inPortIdx = inputPortIdx,
+            .outModIdx = outputModIdx,
+            .outPortIdx = outputPortIdx
+        };
+
+        mLoadingGraph->cons.push_back(newConnection);
+    }
+
+    // No errors occured during loading, swap loading and runnable graph and return.
+    Graph* temp = mRunnableGraph;
+    mRunnableGraph = mLoadingGraph;
+    mLoadingGraph = temp;
+
+    return mRunnableGraph;
+}
+
+} // namespace graph_infrastructure
+

--- a/base/src/modules/graph_loader.cpp
+++ b/base/src/modules/graph_loader.cpp
@@ -96,7 +96,7 @@ void GraphLoader::validateGraph(Graph* graph) {
 ///
 Graph* GraphLoader::load(char* buf, size_t len) {
     ArduinoJson::JsonDocument doc;
-    ArduinoJson::DeserializationError err = deserializeJson(doc, buf);
+    ArduinoJson::DeserializationError err = deserializeJson(doc, buf, len);
 
     ArduinoJson::JsonObject obj = doc.as<ArduinoJson::JsonObject>();
 

--- a/base/src/modules/graph_loader.cpp
+++ b/base/src/modules/graph_loader.cpp
@@ -50,6 +50,7 @@ void GraphLoader::clearGraph(Graph* graph) {
 
 ///
 /// Validate the graph that has been loaded.
+/// @param graph The graph to validate.
 ///
 void GraphLoader::validateGraph(Graph* graph) {
 
@@ -171,7 +172,7 @@ void GraphLoader::parseModules(ArduinoJson::JsonObject& obj) {
 ///
 /// Parse connections and load into graph.
 /// @param obj JSON object to parse connections from.
-/// @note @ref All modules should be loaded into the graph before calling this.
+/// @note All modules should be loaded into the graph before calling this.
 ///
 void GraphLoader::parseConnections(ArduinoJson::JsonObject& obj) {
     ArduinoJson::JsonArray connections = obj[scModulesJsonKey];

--- a/base/src/modules/graph_loader.cpp
+++ b/base/src/modules/graph_loader.cpp
@@ -77,12 +77,12 @@ void GraphLoader::validateGraph(Graph* graph) {
         module_basics::ModuleInterface* inMod = graph->mods[con.inModIdx];
         module_basics::ModuleInterface* outMod = graph->mods[con.outModIdx];
 
-        if(!inMod->outputExists(con.inPortIdx)) {
-            throw "Invalid connection input port";
+        if(!outMod->outputExists(con.outPortIdx)) {
+            throw "Invalid connection output port";
         }
 
-        if(!outMod->inputExists(con.outPortIdx)) {
-            throw "Invalid connection output port";
+        if(!inMod->inputExists(con.inPortIdx)) {
+            throw "Invalid connection input port";
         }
     }
 }
@@ -109,6 +109,9 @@ Graph* GraphLoader::load(char* buf, size_t len) {
 
     parseModules(obj);
     parseConnections(obj);
+
+    // Validate loaded graph
+    validateGraph(mLoadingGraph);
 
     // No errors occured during loading, swap loading and runnable graph and return.
     Graph* temp = mRunnableGraph;

--- a/base/src/modules/graph_loader.cpp
+++ b/base/src/modules/graph_loader.cpp
@@ -87,7 +87,13 @@ void GraphLoader::validateGraph(Graph* graph) {
 
     // TODO: Check The inputs of every module is pointed to by 0 or 1 connection.
 }
-
+///
+/// Load a new graph from input
+/// @param buf
+/// @param len
+/// @return 
+///
+// TODO: Split this up
 Graph* GraphLoader::load(char* buf, size_t len) {
     ArduinoJson::JsonDocument doc;
     ArduinoJson::DeserializationError err = deserializeJson(doc, buf, len);
@@ -109,7 +115,7 @@ Graph* GraphLoader::load(char* buf, size_t len) {
         throw "Invalid connections key";
     }
 
-    // prepare graph for loading.
+    // Prepare graph for loading.
     clearGraph(mLoadingGraph);
 
     // Parse Modules
@@ -145,6 +151,9 @@ Graph* GraphLoader::load(char* buf, size_t len) {
         }
 
         module_basics::ModuleInterface* newModule = mModuleLoader.loadModule(moduleId);
+        if(!newModule) {
+            throw "Module lookup failed";
+        }
         mLoadingGraph->mods.push_back(newModule);
         newModule->configure(moduleArgs);
     }
@@ -177,7 +186,7 @@ Graph* GraphLoader::load(char* buf, size_t len) {
         size_t outputModIdx = connection[scConnectionsOutputModJsonKey];
 
         if(inputModIdx >= mLoadingGraph->mods.size()) {
-        throw scInvalidConnectionInputMod;
+            throw scInvalidConnectionInputMod;
         }
 
         if(outputModIdx >= mLoadingGraph->mods.size()) {

--- a/base/src/modules/graph_loader.hpp
+++ b/base/src/modules/graph_loader.hpp
@@ -2,6 +2,7 @@
 
 #include "graph.hpp"
 #include "module_loader_interface.hpp"
+#include <ArduinoJson.hpp>
 
 namespace graph_infrastructure {
 
@@ -18,6 +19,9 @@ public:
 private:
     static void validateGraph(Graph* graph);
     static void clearGraph(Graph* graph);
+
+    void parseModules(ArduinoJson::JsonObject& obj);
+    void parseConnections(ArduinoJson::JsonObject& obj);
 
     // Graph double buffer so that if new graph fails to load, current graph does not get deleted.
     Graph mGraphA; ///< First graph

--- a/base/src/modules/graph_loader.hpp
+++ b/base/src/modules/graph_loader.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "graph.hpp"
+#include "module_loader_interface.hpp"
+
+namespace graph_infrastructure {
+
+///
+/// Class for loading graph from a text input.
+///
+class GraphLoader {
+public:
+    GraphLoader(ModuleLoaderInterface& moduleLoader);
+
+    virtual ~GraphLoader();
+
+    Graph* load(char* input, size_t len);
+private:
+    static void validateGraph(Graph* graph);
+    static void clearGraph(Graph* graph);
+
+    // Graph double buffer so that if new graph fails to load, current graph does not get deleted.
+    Graph mGraphA; ///< First graph
+    Graph mGraphB; ///< Second graph
+    Graph* mRunnableGraph = &mGraphA; ///< Fully loaded graph ready for running
+    Graph* mLoadingGraph = &mGraphB; ///< Cleared graph, ready for loading
+
+    ModuleLoaderInterface& mModuleLoader; ///< Module loader.
+};
+
+} // namespace graph_infrastructure

--- a/base/src/modules/graph_runner.cpp
+++ b/base/src/modules/graph_runner.cpp
@@ -85,8 +85,8 @@ inline void GraphRunner::fastCallBack() noexcept {
 
     // Loop through all connections and move data.
     for(Connection& con : mGraph->cons) {
-        uint16_t val = mGraph->mods[con.inModIdx]->getOutput(con.inPortIdx);
-        mGraph->mods[con.outModIdx]->setInput(con.outPortIdx, val);
+        uint16_t val = mGraph->mods[con.outModIdx]->getOutput(con.outPortIdx);
+        mGraph->mods[con.inModIdx]->setInput(con.inPortIdx, val);
     }
 
     // Update our boards fast IO.

--- a/base/src/modules/graph_runner.hpp
+++ b/base/src/modules/graph_runner.hpp
@@ -49,3 +49,4 @@ private:
 };
 
 } // namespace graph_infrastructure
+

--- a/base/src/modules/module_basics.hpp
+++ b/base/src/modules/module_basics.hpp
@@ -56,14 +56,14 @@ public:
     /// @param name Name of the input to get the index of.
     /// @return The index of the input with the corresponding name.
     ///
-  	virtual size_t getInputIdx(std::string name) = 0;
+    virtual size_t getInputIdx(std::string name) = 0;
 
     ///
     /// Get the index of an output given the output name.
     /// @param name Name of the output to get the index of.
     /// @return The index of the output with the corresponding name.
     ///
-  	virtual size_t getOutputIdx(std::string name) = 0;
+    virtual size_t getOutputIdx(std::string name) = 0;
 
     ///
     /// Run function, performs a single cycle of module processing, reads inputs and sets outputs.
@@ -75,8 +75,9 @@ public:
     /// Initial configuration of module. Will be called once during module instantiation.
     /// @param params User parameters for the module. Keys are parameter names while values are parameter values.
     /// @note Casting to appropriate types should happen inside this function. May throw if parameter is not present or malformed.
+    /// @note params will go out of scope after this function returns, make copies as necessary.
     ///
-    virtual void configure(std::unordered_map<std::string, std::string> params) = 0;
+    virtual void configure(std::unordered_map<std::string, std::string>& params) = 0;
 };
 
 ///

--- a/base/src/modules/module_basics.hpp
+++ b/base/src/modules/module_basics.hpp
@@ -7,6 +7,8 @@
 
 namespace module_basics {
 
+typedef uint64_t ModuleIdType; ///< Type to use for module ID, used internally.
+
 ///
 /// Interface for interacting with a module.
 /// @note Modules should not inherit directly from this class. see @ref ModuleBase

--- a/base/src/modules/module_loader.cpp
+++ b/base/src/modules/module_loader.cpp
@@ -6,14 +6,14 @@ namespace graph_infrastructure {
 /// Modules that utilize board HW
 ///
 std::unordered_map<module_basics::ModuleIdType, std::function<module_basics::ModuleInterface*(board::BoardInterface&)>> ModuleLoader::sHardwareModules = {
-
+    // Add hardware modules as they become available.
 };
 
 ///
 /// Modules that are hard coded into the FW
 ///
 std::unordered_map<module_basics::ModuleIdType, std::function<module_basics::ModuleInterface*()>> ModuleLoader::sStaticModules = {
-
+    // Add static modules as they become available.
 };
 
 ///

--- a/base/src/modules/module_loader.cpp
+++ b/base/src/modules/module_loader.cpp
@@ -5,14 +5,14 @@ namespace graph_infrastructure {
 ///
 /// Modules that utilize board HW
 ///
-std::unordered_map<uint64_t, std::function<module_basics::ModuleInterface*(board::BoardInterface&)>> ModuleLoader::sHardwareModules = {
+std::unordered_map<module_basics::ModuleIdType, std::function<module_basics::ModuleInterface*(board::BoardInterface&)>> ModuleLoader::sHardwareModules = {
 
 };
 
 ///
 /// Modules that are hard coded into the FW
 ///
-std::unordered_map<uint64_t, std::function<module_basics::ModuleInterface*()>> ModuleLoader::sStaticModules = {
+std::unordered_map<module_basics::ModuleIdType, std::function<module_basics::ModuleInterface*()>> ModuleLoader::sStaticModules = {
 
 };
 
@@ -29,7 +29,7 @@ ModuleLoader::ModuleLoader(board::BoardInterface& board): mBoard(board) {
 /// @param modId Module ID to load.
 /// @return Pointer to new module on the heap, NULL if not found.
 ///
-module_basics::ModuleInterface* ModuleLoader::loadModule(uint64_t modId) {
+module_basics::ModuleInterface* ModuleLoader::loadModule(module_basics::ModuleIdType modId) {
     module_basics::ModuleInterface* mod = NULL;
 
     mod = loadHardwareModule(modId);
@@ -46,7 +46,7 @@ module_basics::ModuleInterface* ModuleLoader::loadModule(uint64_t modId) {
 /// @param modId Module ID to load.
 /// @return Pointer to new module on the heap, NULL if not found.
 ///
-module_basics::ModuleInterface* ModuleLoader::loadHardwareModule(uint64_t modId) {
+module_basics::ModuleInterface* ModuleLoader::loadHardwareModule(module_basics::ModuleIdType modId) {
     if(sHardwareModules.count(modId) > 0) {
         return sHardwareModules[modId](mBoard);
     }
@@ -58,7 +58,7 @@ module_basics::ModuleInterface* ModuleLoader::loadHardwareModule(uint64_t modId)
 /// @param modId Module ID to load.
 /// @return Pointer to new module on the heap, NULL if not found.
 ///
-module_basics::ModuleInterface* ModuleLoader::loadStaticModule(uint64_t modId) {
+module_basics::ModuleInterface* ModuleLoader::loadStaticModule(module_basics::ModuleIdType modId) {
     if(sStaticModules.count(modId) > 0) {
         return sStaticModules[modId]();
     }

--- a/base/src/modules/module_loader.cpp
+++ b/base/src/modules/module_loader.cpp
@@ -1,0 +1,68 @@
+#include "module_loader.hpp"
+
+namespace graph_infrastructure {
+
+///
+/// Modules that utilize board HW
+///
+std::unordered_map<uint64_t, std::function<module_basics::ModuleInterface*(board::BoardInterface&)>> ModuleLoader::sHardwareModules = {
+
+};
+
+///
+/// Modules that are hard coded into the FW
+///
+std::unordered_map<uint64_t, std::function<module_basics::ModuleInterface*()>> ModuleLoader::sStaticModules = {
+
+};
+
+///
+/// Constructor.
+/// @param board Reference to the board.
+///
+ModuleLoader::ModuleLoader(board::BoardInterface& board): mBoard(board) {
+    ; // Do nothing.
+}
+
+///
+/// Attempt to load a module.
+/// @param modId Module ID to load.
+/// @return Pointer to new module on the heap, NULL if not found.
+///
+module_basics::ModuleInterface* ModuleLoader::loadModule(uint64_t modId) {
+    module_basics::ModuleInterface* mod = NULL;
+
+    mod = loadHardwareModule(modId);
+
+    if(!mod) {
+        mod = loadStaticModule(modId);
+    }
+
+    return mod;
+}
+
+///
+/// Attempt to load a hardware dependent module.
+/// @param modId Module ID to load.
+/// @return Pointer to new module on the heap, NULL if not found.
+///
+module_basics::ModuleInterface* ModuleLoader::loadHardwareModule(uint64_t modId) {
+    if(sHardwareModules.count(modId) > 0) {
+        return sHardwareModules[modId](mBoard);
+    }
+    return NULL;
+}
+
+///
+/// Attempt to load a statically loaded module.
+/// @param modId Module ID to load.
+/// @return Pointer to new module on the heap, NULL if not found.
+///
+module_basics::ModuleInterface* ModuleLoader::loadStaticModule(uint64_t modId) {
+    if(sStaticModules.count(modId) > 0) {
+        return sStaticModules[modId]();
+    }
+    return NULL;
+}
+
+} // namespace graph_infrastructure

--- a/base/src/modules/module_loader.hpp
+++ b/base/src/modules/module_loader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "module_basics.hpp"
+#include "functional"
 #include "module_loader_interface.hpp"
 #include <board/board_interface.hpp>
 
@@ -17,11 +18,14 @@ public:
     virtual module_basics::ModuleInterface* loadModule(uint64_t moduleId) override;
 
 protected:
-    module_basics::ModuleInterface* loadHwModule(uint64_t moduleId);
+    static std::unordered_map<uint64_t, std::function<module_basics::ModuleInterface*(board::BoardInterface&)>> sHardwareModules;
+    static std::unordered_map<uint64_t, std::function<module_basics::ModuleInterface*()>> sStaticModules;
 
-    module_basics::ModuleInterface* loadDefaultModule(uint64_t moduleId);
+    module_basics::ModuleInterface* loadHardwareModule(uint64_t moduleId);
 
-    board::BoardInterface& mBoard;
+    module_basics::ModuleInterface* loadStaticModule(uint64_t moduleId);
+
+    board::BoardInterface& mBoard; ///< Reference to the board HW.
 };
 
 } // namespace graph_infrastructure

--- a/base/src/modules/module_loader.hpp
+++ b/base/src/modules/module_loader.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <functional>
 #include "module_basics.hpp"
-#include "functional"
 #include "module_loader_interface.hpp"
 #include <board/board_interface.hpp>
 
@@ -15,15 +15,15 @@ class ModuleLoader: public ModuleLoaderInterface {
 public:
     ModuleLoader(board::BoardInterface& board);
 
-    virtual module_basics::ModuleInterface* loadModule(uint64_t moduleId) override;
+    virtual module_basics::ModuleInterface* loadModule(module_basics::ModuleIdType moduleId) override;
 
 protected:
-    static std::unordered_map<uint64_t, std::function<module_basics::ModuleInterface*(board::BoardInterface&)>> sHardwareModules;
-    static std::unordered_map<uint64_t, std::function<module_basics::ModuleInterface*()>> sStaticModules;
+    static std::unordered_map<module_basics::ModuleIdType, std::function<module_basics::ModuleInterface*(board::BoardInterface&)>> sHardwareModules;
+    static std::unordered_map<module_basics::ModuleIdType, std::function<module_basics::ModuleInterface*()>> sStaticModules;
 
-    module_basics::ModuleInterface* loadHardwareModule(uint64_t moduleId);
+    module_basics::ModuleInterface* loadHardwareModule(module_basics::ModuleIdType moduleId);
 
-    module_basics::ModuleInterface* loadStaticModule(uint64_t moduleId);
+    module_basics::ModuleInterface* loadStaticModule(module_basics::ModuleIdType moduleId);
 
     board::BoardInterface& mBoard; ///< Reference to the board HW.
 };

--- a/base/src/modules/module_loader.hpp
+++ b/base/src/modules/module_loader.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "module_basics.hpp"
+#include "module_loader_interface.hpp"
+#include <board/board_interface.hpp>
+
+namespace graph_infrastructure {
+
+///
+/// Class for loading modules
+///
+class ModuleLoader: public ModuleLoaderInterface {
+
+public:
+    ModuleLoader(board::BoardInterface& board);
+
+    virtual module_basics::ModuleInterface* loadModule(uint64_t moduleId) override;
+
+protected:
+    module_basics::ModuleInterface* loadHwModule(uint64_t moduleId);
+
+    module_basics::ModuleInterface* loadDefaultModule(uint64_t moduleId);
+
+    board::BoardInterface& mBoard;
+};
+
+} // namespace graph_infrastructure
+

--- a/base/src/modules/module_loader_interface.hpp
+++ b/base/src/modules/module_loader_interface.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "module_basics.hpp"
+
+namespace graph_infrastructure {
+
+///
+/// Interface for module loaders.
+///
+class ModuleLoaderInterface {
+public:
+
+    ///
+    /// Default destructor.
+    ///
+    virtual ~ModuleLoaderInterface() = default;
+
+    ///
+    /// Load and return a new module.
+    /// @param moduleId Id of the module to load.
+    /// @return Module pointer or NULL if module could not be found.
+    ///
+    virtual module_basics::ModuleInterface* loadModule(uint64_t moduleId) = 0;
+};
+
+} // namespace graph_infrastructure

--- a/base/src/modules/module_loader_interface.hpp
+++ b/base/src/modules/module_loader_interface.hpp
@@ -20,7 +20,7 @@ public:
     /// @param moduleId Id of the module to load.
     /// @return Module pointer or NULL if module could not be found.
     ///
-    virtual module_basics::ModuleInterface* loadModule(uint64_t moduleId) = 0;
+    virtual module_basics::ModuleInterface* loadModule(module_basics::ModuleIdType moduleId) = 0;
 };
 
 } // namespace graph_infrastructure

--- a/base/src/test_test/module_infrastructure_test.cpp
+++ b/base/src/test_test/module_infrastructure_test.cpp
@@ -239,8 +239,6 @@ TEST(GraphLoaderCoreTests, GraphLoaderHappyPath) {
             ]\
         }\
     ";
-    std::cout << validGraphJson << std::endl;
-
     MockModuleLoader moduleLoader;
 
     graph_infrastructure::GraphLoader graphLoader(moduleLoader);
@@ -429,6 +427,97 @@ TEST(GraphLoaderCoreTests, GraphLoaderSadPaths) {
     }, const char*);
 }
 
+bool compareConnections(graph_infrastructure::Connection lhs, graph_infrastructure::Connection rhs) {
+    return lhs.inModIdx == rhs.inModIdx &&
+        lhs.inPortIdx == rhs.inPortIdx &&
+        lhs.outPortIdx == rhs.outPortIdx &&
+        lhs.outModIdx == rhs.outModIdx;
+}
+
 TEST(GraphLoaderCoreTests, GraphLoaderDoubleBufferingTest) {
-    //TODO: Test double buffering system of graph loader
+    MockModuleLoader moduleLoader;
+    graph_infrastructure::GraphLoader graphLoader(moduleLoader);
+
+    const char* validGraphJson = "\
+        {\
+            \"modules\": [\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                },\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                }\
+            ],\
+            \"connections\": [\
+                {\
+                    \"input_mod\": 0,\
+                    \"input_port_name\": \"mock\",\
+                    \"output_mod\": 1,\
+                    \"output_port_name\": \"mock\"\
+                }\
+            ]\
+        }\
+    ";
+
+    const char* invalidGraphJson = "\
+        {\
+            \"modules\": [\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                },\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                }\
+            ],\
+            \"connections\": [\
+                {\
+                    \"input_mod\": 0,\
+                    \"input_port_name\": \"mock\",\
+                    \"output_mod\": 9,\
+                    \"output_port_name\": \"mock\"\
+                }\
+            ]\
+        }\
+    ";
+
+    // Test that the second graph loading gives us a new pointer
+    graph_infrastructure::Graph* ogGraph = graphLoader.load(const_cast<char*>(validGraphJson), strlen(validGraphJson));
+    graph_infrastructure::Graph* newGraph = graphLoader.load(const_cast<char*>(validGraphJson), strlen(validGraphJson));
+
+    EXPECT_NE(ogGraph, newGraph);
+
+    // Test that on a failed load the previously loaded graph is still the same.
+    graph_infrastructure::Graph newGraphCopy;
+    newGraphCopy.mods = newGraph->mods;
+    newGraphCopy.cons = newGraph->cons;
+
+    EXPECT_THROW({
+        graphLoader.load(const_cast<char*>(invalidGraphJson), strlen(invalidGraphJson));
+    }, const char*);
+
+    EXPECT_EQ(newGraph->mods, newGraphCopy.mods);
+    // Manually compare connections
+    EXPECT_EQ(newGraph->cons.size(), newGraphCopy.cons.size());
+    for(size_t i = 0; i < newGraph->cons.size(); i++) {
+        EXPECT_TRUE(compareConnections(newGraph->cons[i], newGraphCopy.cons[i]));
+    }
+
+    // Check that loading a third time works
+    const char* emptyGraphJson = "\
+        {\
+            \"modules\": [\
+           ],\
+            \"connections\": [\
+           ]\
+        }\
+    ";
+    graph_infrastructure::Graph* emptyGraph = graphLoader.load(const_cast<char*>(emptyGraphJson), strlen(emptyGraphJson));
+
+    EXPECT_EQ(emptyGraph->mods.size(), 0);
+    EXPECT_EQ(emptyGraph->cons.size(), 0);
+
 }

--- a/base/src/test_test/module_infrastructure_test.cpp
+++ b/base/src/test_test/module_infrastructure_test.cpp
@@ -1,14 +1,26 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include "modules/module_basics.hpp"
-#include "modules/graph_runner.hpp"
+#include <modules/module_basics.hpp>
+#include <modules/graph_runner.hpp>
+#include <modules/graph_loader.hpp>
 
+static constexpr size_t scMockPortIdx = 0;
 // Test double deriving from the actual base class template
 template<size_t I, size_t O>
 class MockModule : public module_basics::ModuleBase<I, O> {
 public:
-    MOCK_METHOD(size_t, getInputIdx, (std::string name), (override));
-    MOCK_METHOD(size_t, getOutputIdx, (std::string name), (override));
+    size_t getInputIdx(std::string name) override {
+        if(name == "mock") {
+            return scMockPortIdx;
+        }
+        return -1;
+    }
+    size_t getOutputIdx(std::string name) override {
+        if(name == "mock") {
+            return scMockPortIdx;
+        }
+        return -1;
+    }
 
     MOCK_METHOD(void, run, (), (noexcept, override));
 
@@ -187,4 +199,69 @@ TEST_F(GraphRunnerFunctionalityTestFixture, VerifiesGraphRunnerCallsModuleRun) {
     board.mTimer.tick();
  
     // 3. gmock will automatically fail the test here if run() wasn't called exactly once!
+}
+
+class MockModuleLoader: public graph_infrastructure::ModuleLoaderInterface {
+public:
+    static constexpr module_basics::ModuleIdType scMockModuleId = 0;
+    static constexpr size_t scMockModuleNumInputs = 1;
+    static constexpr size_t scMockModuleNumOutputs = 1;
+
+    virtual module_basics::ModuleInterface* loadModule(module_basics::ModuleIdType modId) override {
+        if(modId == scMockModuleId) {
+            return new MockModule<scMockModuleNumInputs, scMockModuleNumOutputs>();
+        }
+        return NULL;
+    }
+};
+
+TEST(GraphLoaderCoreTests, GraphLoaderHappyPath) {
+    const char* validGraphJson = "\
+        {\
+            \"modules\": [\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                },\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                }\
+            ],\
+            \"connections\": [\
+                {\
+                    \"input_mod\": 0,\
+                    \"input_port_name\": \"mock\",\
+                    \"output_mod\": 1,\
+                    \"output_port_name\": \"mock\"\
+                }\
+            ]\
+        }\
+    ";
+    std::cout << validGraphJson << std::endl;
+
+    MockModuleLoader moduleLoader;
+
+    graph_infrastructure::GraphLoader graphLoader(moduleLoader);
+    graph_infrastructure::Graph* g = graphLoader.load(const_cast<char*>(validGraphJson), sizeof(validGraphJson));
+
+    // Make sure that graph is not NULL
+    EXPECT_NE(g, nullptr);
+
+    // Make sure that 2 modules were added to the graph
+    EXPECT_EQ(g->mods.size(), 2);
+
+    // Make sure that all modules are not NULL
+    for(module_basics::ModuleInterface* mod : g->mods) {
+        EXPECT_NE(mod, nullptr);
+    }
+
+    // Make sure there is one connection
+    EXPECT_EQ(g->cons.size(), 1);
+
+    // Make sure that both input and output of that connection point to the mock port
+    EXPECT_EQ(g->cons[0].inPortIdx, scMockPortIdx);
+    EXPECT_EQ(g->cons[0].outPortIdx, scMockPortIdx);
+
+    //TODO: Check input and output module indices and add sad path tests :(
 }

--- a/base/src/test_test/module_infrastructure_test.cpp
+++ b/base/src/test_test/module_infrastructure_test.cpp
@@ -12,7 +12,7 @@ public:
 
     MOCK_METHOD(void, run, (), (noexcept, override));
 
-    MOCK_METHOD(void, configure, ((std::unordered_map<std::string, std::string>)), (override));
+    MOCK_METHOD(void, configure, ((std::unordered_map<std::string, std::string>&)), (override));
 
     // Expose protected fields from ModuleBase for verification
     uint16_t inspectInputArray(size_t idx) const { return this->mInputs[idx]; }

--- a/base/src/test_test/module_infrastructure_test.cpp
+++ b/base/src/test_test/module_infrastructure_test.cpp
@@ -5,7 +5,7 @@
 #include <modules/graph_loader.hpp>
 
 static constexpr size_t scMockPortInputIdx = 0;
-static constexpr size_t scMockPortOutputIdx = 1;
+static constexpr size_t scMockPortOutputIdx = 0;
 // Test double deriving from the actual base class template
 template<size_t I, size_t O>
 class MockModule : public module_basics::ModuleBase<I, O> {
@@ -14,13 +14,13 @@ public:
         if(name == "mock") {
             return scMockPortInputIdx;
         }
-        return -1;
+        return scMockPortInputIdx+1;
     }
     size_t getOutputIdx(std::string name) override {
         if(name == "mock") {
             return scMockPortOutputIdx;
         }
-        return -1;
+        return scMockPortOutputIdx+1;
     }
 
     MOCK_METHOD(void, run, (), (noexcept, override));
@@ -268,15 +268,167 @@ TEST(GraphLoaderCoreTests, GraphLoaderHappyPath) {
     EXPECT_EQ(g->cons[0].outModIdx, 1);
 }
 
+// NOTE: This does not test all the ways that JSON can be malformed
+// That is too much work for what it is worth
 TEST(GraphLoaderCoreTests, GraphLoaderSadPaths) {
-    //TODO: Add following tests
+    MockModuleLoader moduleLoader;
+    graph_infrastructure::GraphLoader graphLoader(moduleLoader);
+
     // Test invalid module id
+    const char* invalidModuleIdGraphJson = "\
+        {\
+            \"modules\": [\
+                {\
+                    \"id\": 6,\
+                    \"args\": {}\
+                }\
+           ]\
+        }\
+    ";
+    EXPECT_THROW({
+        try {
+            graphLoader.load(const_cast<char*>(invalidModuleIdGraphJson), strlen(invalidModuleIdGraphJson));
+        } catch(const char* e) {
+            // Ensure that it throws an error referencing the module
+            EXPECT_THAT(e, ::testing::HasSubstr("Module"));
+            throw;
+        }
+    }, const char*);
 
     // Test invalid input module
+    const char* invalidInputModuleGraphJson = "\
+        {\
+            \"modules\": [\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                },\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                }\
+            ],\
+            \"connections\": [\
+                {\
+                    \"input_mod\": 9,\
+                    \"input_port_name\": \"mock\",\
+                    \"output_mod\": 1,\
+                    \"output_port_name\": \"mock\"\
+                }\
+            ]\
+        }\
+    ";
+    EXPECT_THROW({
+        try {
+            graphLoader.load(const_cast<char*>(invalidInputModuleGraphJson), strlen(invalidInputModuleGraphJson));
+        } catch(const char* e) {
+            // Ensure that it throws an error referencing the input module
+            EXPECT_THAT(e, ::testing::HasSubstr("input module"));
+            throw;
+        }
+    }, const char*);
 
     // Test invalid output module
+    const char* invalidOutputModuleGraphJson = "\
+        {\
+            \"modules\": [\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                },\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                }\
+            ],\
+            \"connections\": [\
+                {\
+                    \"input_mod\": 0,\
+                    \"input_port_name\": \"mock\",\
+                    \"output_mod\": 9,\
+                    \"output_port_name\": \"mock\"\
+                }\
+            ]\
+        }\
+    ";
+    EXPECT_THROW({
+        try {
+            graphLoader.load(const_cast<char*>(invalidOutputModuleGraphJson), strlen(invalidOutputModuleGraphJson));
+        } catch(const char* e) {
+            // Ensure that it throws an error referencing the output module
+            EXPECT_THAT(e, ::testing::HasSubstr("output module"));
+            throw;
+        }
+    }, const char*);
 
     // Test invalid input port
+    const char* invalidInputPortGraphJson = "\
+        {\
+            \"modules\": [\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                },\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                }\
+            ],\
+            \"connections\": [\
+                {\
+                    \"input_mod\": 0,\
+                    \"input_port_name\": \"invalid\",\
+                    \"output_mod\": 1,\
+                    \"output_port_name\": \"mock\"\
+                }\
+            ]\
+        }\
+    ";
+    EXPECT_THROW({
+        try {
+            graphLoader.load(const_cast<char*>(invalidInputPortGraphJson), strlen(invalidInputPortGraphJson));
+        } catch(const char* e) {
+            // Ensure that it throws an error referencing the input port
+            EXPECT_THAT(e, ::testing::HasSubstr("input port"));
+            throw;
+        }
+    }, const char*);
 
     // Test invalid output port
+    const char* invalidOutputPortGraphJson = "\
+        {\
+            \"modules\": [\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                },\
+                {\
+                    \"id\": 0,\
+                    \"args\": {}\
+                }\
+            ],\
+            \"connections\": [\
+                {\
+                    \"input_mod\": 0,\
+                    \"input_port_name\": \"mock\",\
+                    \"output_mod\": 1,\
+                    \"output_port_name\": \"invalid\"\
+                }\
+            ]\
+        }\
+    ";
+    EXPECT_THROW({
+        try {
+            graphLoader.load(const_cast<char*>(invalidOutputPortGraphJson), strlen(invalidOutputPortGraphJson));
+        } catch(const char* e) {
+            std::cout << e << std::endl;
+            // Ensure that it throws an error referencing the output port
+            EXPECT_THAT(e, ::testing::HasSubstr("output port"));
+            throw;
+        }
+    }, const char*);
+}
+
+TEST(GraphLoaderCoreTests, GraphLoaderDoubleBufferingTest) {
+    //TODO: Test double buffering system of graph loader
 }

--- a/base/src/test_test/module_infrastructure_test.cpp
+++ b/base/src/test_test/module_infrastructure_test.cpp
@@ -4,20 +4,21 @@
 #include <modules/graph_runner.hpp>
 #include <modules/graph_loader.hpp>
 
-static constexpr size_t scMockPortIdx = 0;
+static constexpr size_t scMockPortInputIdx = 0;
+static constexpr size_t scMockPortOutputIdx = 1;
 // Test double deriving from the actual base class template
 template<size_t I, size_t O>
 class MockModule : public module_basics::ModuleBase<I, O> {
 public:
     size_t getInputIdx(std::string name) override {
         if(name == "mock") {
-            return scMockPortIdx;
+            return scMockPortInputIdx;
         }
         return -1;
     }
     size_t getOutputIdx(std::string name) override {
         if(name == "mock") {
-            return scMockPortIdx;
+            return scMockPortOutputIdx;
         }
         return -1;
     }
@@ -243,7 +244,7 @@ TEST(GraphLoaderCoreTests, GraphLoaderHappyPath) {
     MockModuleLoader moduleLoader;
 
     graph_infrastructure::GraphLoader graphLoader(moduleLoader);
-    graph_infrastructure::Graph* g = graphLoader.load(const_cast<char*>(validGraphJson), sizeof(validGraphJson));
+    graph_infrastructure::Graph* g = graphLoader.load(const_cast<char*>(validGraphJson), strlen(validGraphJson));
 
     // Make sure that graph is not NULL
     EXPECT_NE(g, nullptr);
@@ -260,8 +261,22 @@ TEST(GraphLoaderCoreTests, GraphLoaderHappyPath) {
     EXPECT_EQ(g->cons.size(), 1);
 
     // Make sure that both input and output of that connection point to the mock port
-    EXPECT_EQ(g->cons[0].inPortIdx, scMockPortIdx);
-    EXPECT_EQ(g->cons[0].outPortIdx, scMockPortIdx);
+    EXPECT_EQ(g->cons[0].inPortIdx, scMockPortInputIdx);
+    EXPECT_EQ(g->cons[0].outPortIdx, scMockPortOutputIdx);
 
-    //TODO: Check input and output module indices and add sad path tests :(
+    EXPECT_EQ(g->cons[0].inModIdx, 0);
+    EXPECT_EQ(g->cons[0].outModIdx, 1);
+}
+
+TEST(GraphLoaderCoreTests, GraphLoaderSadPaths) {
+    //TODO: Add following tests
+    // Test invalid module id
+
+    // Test invalid input module
+
+    // Test invalid output module
+
+    // Test invalid input port
+
+    // Test invalid output port
 }


### PR DESCRIPTION
- Added graph loader that will parse graph description based on JSON schema in gooey_specs repo
- Uses dual slot system to ensure that a failure in loading new graph does not erase old graph
- Added ModuleLoader and ModuleLoaderInterface with hooks for adding in new static and hardware-dependent modules
- (Hopefully) added clarity to connection description.
- Fixed error in graph runner
- General cleanup